### PR TITLE
Feat(1) : 카카오맵 API 활용 컴포넌트 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 *.sln
 *.sw?
 .vercel
+.env

--- a/package.json
+++ b/package.json
@@ -17,8 +17,11 @@
   },
   "devDependencies": {
     "@eslint/js": "^8.57.0",
+    "@types/node": "^22.14.0",
     "@types/react": "^18.2.64",
     "@types/react-dom": "^18.2.21",
+    "@typescript-eslint/eslint-plugin": "^7.1.1",
+    "@typescript-eslint/parser": "^7.1.1",
     "@vitejs/plugin-react": "^4.2.1",
     "autoprefixer": "^10.4.17",
     "eslint": "^8.57.0",
@@ -30,8 +33,6 @@
     "prettier": "^3.2.5",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3",
-    "@typescript-eslint/eslint-plugin": "^7.1.1",
-    "@typescript-eslint/parser": "^7.1.1",
     "vite": "^5.1.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@eslint/js':
         specifier: ^8.57.0
         version: 8.57.1
+      '@types/node':
+        specifier: ^22.14.0
+        version: 22.14.0
       '@types/react':
         specifier: ^18.2.64
         version: 18.3.20
@@ -38,7 +41,7 @@ importers:
         version: 7.18.0(eslint@8.57.1)(typescript@5.7.3)
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.3.4(vite@5.4.17(lightningcss@1.29.2))
+        version: 4.3.4(vite@5.4.17(@types/node@22.14.0)(lightningcss@1.29.2))
       autoprefixer:
         specifier: ^10.4.17
         version: 10.4.21(postcss@8.5.3)
@@ -71,7 +74,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^5.1.6
-        version: 5.4.17(lightningcss@1.29.2)
+        version: 5.4.17(@types/node@22.14.0)(lightningcss@1.29.2)
 
 packages:
 
@@ -486,6 +489,9 @@ packages:
 
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
+
+  '@types/node@22.14.0':
+    resolution: {integrity: sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==}
 
   '@types/prop-types@15.7.14':
     resolution: {integrity: sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==}
@@ -1419,6 +1425,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   update-browserslist-db@1.1.3:
     resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
     hasBin: true
@@ -1843,6 +1852,10 @@ snapshots:
 
   '@types/estree@1.0.7': {}
 
+  '@types/node@22.14.0':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/prop-types@15.7.14': {}
 
   '@types/react-dom@18.3.6(@types/react@18.3.20)':
@@ -1937,14 +1950,14 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.3.4(vite@5.4.17(lightningcss@1.29.2))':
+  '@vitejs/plugin-react@4.3.4(vite@5.4.17(@types/node@22.14.0)(lightningcss@1.29.2))':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.10)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.4.17(lightningcss@1.29.2)
+      vite: 5.4.17(@types/node@22.14.0)(lightningcss@1.29.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -2778,6 +2791,8 @@ snapshots:
 
   typescript@5.7.3: {}
 
+  undici-types@6.21.0: {}
+
   update-browserslist-db@1.1.3(browserslist@4.24.4):
     dependencies:
       browserslist: 4.24.4
@@ -2790,12 +2805,13 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite@5.4.17(lightningcss@1.29.2):
+  vite@5.4.17(@types/node@22.14.0)(lightningcss@1.29.2):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.3
       rollup: 4.39.0
     optionalDependencies:
+      '@types/node': 22.14.0
       fsevents: 2.3.3
       lightningcss: 1.29.2
 

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -1,10 +1,7 @@
-import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
+  <App />
 )

--- a/src/features/mapView/index.ts
+++ b/src/features/mapView/index.ts
@@ -1,0 +1,3 @@
+export * from "./ui/index";
+export * from "./service/index";
+export * from "./model/index";

--- a/src/features/mapView/ui/KakaoMapView.tsx
+++ b/src/features/mapView/ui/KakaoMapView.tsx
@@ -13,8 +13,9 @@ function KakaoMapView() {
 
       window.kakao.maps.load(() => {
         if (mapRef.current) {
-          // 초기 중심점 설정 (서울 시청)
-          const center = new window.kakao.maps.LatLng(37.5665, 126.9780);
+          // mockLocationData의 첫 번째 위치를 초기 중심점으로 설정
+          const firstLocation = mockLocationData.locations[0];
+          const center = new window.kakao.maps.LatLng(firstLocation.lat, firstLocation.lng);
           const options = {
             center,
             level: 3,

--- a/src/features/mapView/ui/KakaoMapView.tsx
+++ b/src/features/mapView/ui/KakaoMapView.tsx
@@ -13,6 +13,7 @@ function KakaoMapView() {
 
       window.kakao.maps.load(() => {
         if (mapRef.current) {
+          // 초기 중심점 설정 (서울 시청)
           const center = new window.kakao.maps.LatLng(37.5665, 126.9780);
           const options = {
             center,
@@ -21,6 +22,17 @@ function KakaoMapView() {
 
           const kakaoMap = new window.kakao.maps.Map(mapRef.current, options);
           setMap(kakaoMap);
+
+          // 모든 마커의 위치를 포함하는 LatLngBounds 객체 생성
+          const bounds = new window.kakao.maps.LatLngBounds();
+          
+          // mockLocationData의 모든 위치를 bounds에 추가
+          mockLocationData.locations.forEach(location => {
+            bounds.extend(new window.kakao.maps.LatLng(location.lat, location.lng));
+          });
+
+          // 지도에 bounds 적용
+          kakaoMap.setBounds(bounds);
 
           window.kakao.maps.event.addListener(kakaoMap, 'tilesloaded', () => {
             console.log("맵 로드 완료");

--- a/src/features/mapView/ui/KakaoMapView.tsx
+++ b/src/features/mapView/ui/KakaoMapView.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useRef, useState } from "react";
 import MapMarker from "./MapMarker";
-import { mockLocationData } from "../../../shared/model";
+import { mockLocationData } from "@/shared/model";
+
 
 function KakaoMapView() {
   const mapRef = useRef<HTMLDivElement>(null);
-  const [map, setMap] = useState<any>(null);
-  const [center, setCenter] = useState<any>(null);
+
+  const [map, setMap] = useState<kakao.maps.Map | null>(null);
+  const [center, setCenter] = useState<kakao.maps.LatLng | null>(null);
 
   useEffect(() => {
     const initializeMap = () => {
@@ -13,13 +15,12 @@ function KakaoMapView() {
 
       window.kakao.maps.load(() => {
         if (mapRef.current) {
-          // mockLocationData의 midpoint를 초기 중심점으로 설정
           const centerLatLng = new window.kakao.maps.LatLng(
             mockLocationData.midpoint.lat,
             mockLocationData.midpoint.lng
           );
           setCenter(centerLatLng);
-          
+
           const options = {
             center: centerLatLng,
             level: 3,
@@ -28,15 +29,12 @@ function KakaoMapView() {
           const kakaoMap = new window.kakao.maps.Map(mapRef.current, options);
           setMap(kakaoMap);
 
-          // 모든 마커의 위치를 포함하는 LatLngBounds 객체 생성
           const bounds = new window.kakao.maps.LatLngBounds();
-          
-          // mockLocationData의 모든 위치를 bounds에 추가
+
           mockLocationData.locations.forEach(location => {
             bounds.extend(new window.kakao.maps.LatLng(location.lat, location.lng));
           });
 
-          // 지도에 bounds 적용
           kakaoMap.setBounds(bounds);
 
           window.kakao.maps.event.addListener(kakaoMap, 'tilesloaded', () => {
@@ -47,7 +45,7 @@ function KakaoMapView() {
     };
 
     if (document.getElementById("kakao-map-script")) {
-      initializeMap(); // 이미 스크립트 로드된 경우
+      initializeMap();
     } else {
       const script = document.createElement("script");
       script.id = "kakao-map-script";
@@ -55,46 +53,39 @@ function KakaoMapView() {
         import.meta.env.VITE_KAKAO_JAVASCRIPT_KEY
       }&autoload=false&libraries=services,clusterer`;
       script.async = true;
-
       script.onload = () => {
-        initializeMap(); // 스크립트가 로드된 후 초기화
+        initializeMap();
       };
-
       document.head.appendChild(script);
     }
   }, []);
 
-  // midpoint에서 각 마커까지의 Polyline을 그리는 함수
   const drawPolylines = () => {
     if (!map || !center) return;
 
-    // 기존 Polyline 제거
     if (window.polylines) {
-      window.polylines.forEach((polyline: any) => {
+      window.polylines.forEach((polyline: kakao.maps.Polyline) => {
         polyline.setMap(null);
       });
     }
 
-    // 새로운 Polyline 배열 생성
     window.polylines = [];
 
-    // 각 마커 위치에서 midpoint까지 Polyline 그리기
     mockLocationData.locations.forEach(location => {
       const markerLatLng = new window.kakao.maps.LatLng(location.lat, location.lng);
-      
+
       const polyline = new window.kakao.maps.Polyline({
         path: [markerLatLng, center],
         strokeWeight: 3,
         strokeColor: '#FF0000',
         strokeOpacity: 0.7,
-        map: map
+        map: map,
       });
 
       window.polylines.push(polyline);
     });
   };
 
-  // map이나 center가 변경될 때마다 Polyline 다시 그리기
   useEffect(() => {
     drawPolylines();
   }, [map, center]);

--- a/src/features/mapView/ui/KakaoMapView.tsx
+++ b/src/features/mapView/ui/KakaoMapView.tsx
@@ -1,4 +1,7 @@
 import { useEffect, useRef, useState } from "react";
+import MapMarker from "./MapMarker";
+import { mockLocationData } from "../../../shared/model";
+
 
 function KakaoMapView() {
   const mapRef = useRef<HTMLDivElement>(null);
@@ -48,11 +51,20 @@ function KakaoMapView() {
     <div
       ref={mapRef}
       style={{
-        width: "500px",
+        width: "100%",
         height: "500px",
         borderRadius: "8px",
       }}
-    />
+    >
+      {map && mockLocationData.locations.map((location) => (
+        <MapMarker 
+          key={location.id} 
+          map={map} 
+          position={{ lat: location.lat, lng: location.lng }}
+          title={location.name}
+        />
+      ))}
+    </div>
   );
 }
 

--- a/src/features/mapView/ui/KakaoMapView.tsx
+++ b/src/features/mapView/ui/KakaoMapView.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useRef, useState } from "react";
+
+function KakaoMapView() {
+  const mapRef = useRef<HTMLDivElement>(null);
+  const [map, setMap] = useState<any>(null);
+
+  useEffect(() => {
+    const initializeMap = () => {
+      if (!window.kakao || !window.kakao.maps) return;
+
+      window.kakao.maps.load(() => {
+        if (mapRef.current) {
+          const center = new window.kakao.maps.LatLng(37.5665, 126.9780);
+          const options = {
+            center,
+            level: 3,
+          };
+
+          const kakaoMap = new window.kakao.maps.Map(mapRef.current, options);
+          setMap(kakaoMap);
+
+          window.kakao.maps.event.addListener(kakaoMap, 'tilesloaded', () => {
+            console.log("맵 로드 완료");
+          });
+        }
+      });
+    };
+
+    if (document.getElementById("kakao-map-script")) {
+      initializeMap(); // 이미 스크립트 로드된 경우
+    } else {
+      const script = document.createElement("script");
+      script.id = "kakao-map-script";
+      script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${
+        import.meta.env.VITE_KAKAO_JAVASCRIPT_KEY
+      }&autoload=false&libraries=services,clusterer`;
+      script.async = true;
+
+      script.onload = () => {
+        initializeMap(); // 스크립트가 로드된 후 초기화
+      };
+
+      document.head.appendChild(script);
+    }
+  }, []);
+
+  return (
+    <div
+      ref={mapRef}
+      style={{
+        width: "500px",
+        height: "500px",
+        borderRadius: "8px",
+      }}
+    />
+  );
+}
+
+export default KakaoMapView;

--- a/src/features/mapView/ui/MapMarker.tsx
+++ b/src/features/mapView/ui/MapMarker.tsx
@@ -1,8 +1,7 @@
-// src/features/mapView/ui/MapMarker.tsx
 import { useEffect } from 'react';
 
 interface MapMarkerProps {
-  map: any;
+  map: kakao.maps.Map;
   position: {
     lat: number;
     lng: number;

--- a/src/features/mapView/ui/MapMarker.tsx
+++ b/src/features/mapView/ui/MapMarker.tsx
@@ -1,0 +1,36 @@
+// src/features/mapView/ui/MapMarker.tsx
+import { useEffect } from 'react';
+
+interface MapMarkerProps {
+  map: any;
+  position: {
+    lat: number;
+    lng: number;
+  };
+  title?: string;
+  onClick?: () => void;
+}
+
+const MapMarker = ({ map, position, title, onClick }: MapMarkerProps) => {
+  useEffect(() => {
+    if (!map) return;
+
+    const marker = new window.kakao.maps.Marker({
+      position: new window.kakao.maps.LatLng(position.lat, position.lng),
+      map: map,
+      title: title
+    });
+
+    if (onClick) {
+      window.kakao.maps.event.addListener(marker, 'click', onClick);
+    }
+
+    return () => {
+      marker.setMap(null);
+    };
+  }, [map, position, title, onClick]);
+
+  return null;
+};
+
+export default MapMarker;

--- a/src/features/mapView/ui/index.ts
+++ b/src/features/mapView/ui/index.ts
@@ -1,0 +1,1 @@
+export * from "./KakaoMapView";

--- a/src/pages/MapViewPage.tsx
+++ b/src/pages/MapViewPage.tsx
@@ -1,5 +1,11 @@
+import KakaoMapView from "../features/mapView/ui/KakaoMapView";
+
 const MapViewPage = () => {
-  return <div>맵뷰</div>;
+  return (
+    <div>
+      <KakaoMapView />
+    </div>
+  );
 };
 
 export default MapViewPage;

--- a/src/shared/model/index.ts
+++ b/src/shared/model/index.ts
@@ -1,1 +1,1 @@
-export * from "./mocks/MockLocationData";
+export * from "./mocks/mockLocationData";

--- a/src/shared/model/index.ts
+++ b/src/shared/model/index.ts
@@ -1,0 +1,1 @@
+export * from "./mocks/MockLocationData";

--- a/src/shared/model/kakao.maps.d.ts
+++ b/src/shared/model/kakao.maps.d.ts
@@ -1,24 +1,33 @@
+// src/shared/model/kakao.maps.d.ts
 declare global {
-  interface Window {
-    kakao: {
-      maps: {
-        load: (callback: () => void) => void;
-        Map: new (container: HTMLElement, options: {
-          center: any;
-          level: number;
-        }) => any;
-        LatLng: new (lat: number, lng: number) => any;
-        Marker: new (options: {
-          position: any;
-          map: any;
-          title?: string;
-        }) => any;
-        event: {
-          addListener: (target: any, type: string, handler: () => void) => void;
+    interface Window {
+      kakao: {
+        maps: {
+          load: (callback: () => void) => void;
+          Map: new (container: HTMLElement, options: {
+            center: any;
+            level: number;
+          }) => {
+            setBounds: (bounds: any) => void;
+          };
+          LatLng: new (lat: number, lng: number) => any;
+          LatLngBounds: new () => {
+            extend: (latLng: any) => void;
+          };
+          Marker: new (options: {
+            position: any;
+            map: any;
+            title?: string;
+          }) => {
+            setMap: (map: any) => void;
+          };
+          event: {
+            addListener: (target: any, type: string, handler: () => void) => void;
+            removeListener: (target: any, type: string, handler: () => void) => void;
+          };
         };
       };
-    };
+    }
   }
-}
-
-export {}; 
+  
+  export {};

--- a/src/shared/model/kakao.maps.d.ts
+++ b/src/shared/model/kakao.maps.d.ts
@@ -8,6 +8,11 @@ declare global {
           level: number;
         }) => any;
         LatLng: new (lat: number, lng: number) => any;
+        Marker: new (options: {
+          position: any;
+          map: any;
+          title?: string;
+        }) => any;
         event: {
           addListener: (target: any, type: string, handler: () => void) => void;
         };

--- a/src/shared/model/kakao.maps.d.ts
+++ b/src/shared/model/kakao.maps.d.ts
@@ -1,0 +1,19 @@
+declare global {
+  interface Window {
+    kakao: {
+      maps: {
+        load: (callback: () => void) => void;
+        Map: new (container: HTMLElement, options: {
+          center: any;
+          level: number;
+        }) => any;
+        LatLng: new (lat: number, lng: number) => any;
+        event: {
+          addListener: (target: any, type: string, handler: () => void) => void;
+        };
+      };
+    };
+  }
+}
+
+export {}; 

--- a/src/shared/model/kakao.maps.d.ts
+++ b/src/shared/model/kakao.maps.d.ts
@@ -1,43 +1,62 @@
-// src/shared/model/kakao.maps.d.ts
+
+export {}; // 모듈로 인식되도록 설정
+
 declare global {
-    interface Window {
-      kakao: {
-        maps: {
-          load: (callback: () => void) => void;
-          Map: new (container: HTMLElement, options: {
-            center: any;
-            level: number;
-          }) => {
-            setBounds: (bounds: any) => void;
-          };
-          LatLng: new (lat: number, lng: number) => any;
-          LatLngBounds: new () => {
-            extend: (latLng: any) => void;
-          };
-          Marker: new (options: {
-            position: any;
-            map: any;
-            title?: string;
-          }) => {
-            setMap: (map: any) => void;
-          };
-          Polyline: new (options: {
-            path: any[];
-            strokeWeight: number;
-            strokeColor: string;
-            strokeOpacity: number;
-            map: any;
-          }) => {
-            setMap: (map: any) => void;
-          };
-          event: {
-            addListener: (target: any, type: string, handler: () => void) => void;
-            removeListener: (target: any, type: string, handler: () => void) => void;
-          };
-        };
-      };
-      polylines: any[];
+  interface Window {
+    kakao: typeof kakao;
+    polylines: kakao.maps.Polyline[];
+  }
+
+  namespace kakao {
+    namespace maps {
+      class LatLng {
+        constructor(lat: number, lng: number);
+      }
+
+      class LatLngBounds {
+        extend(latlng: LatLng): void;
+      }
+
+      class Map {
+        constructor(container: HTMLElement, options: { center: LatLng; level: number });
+        setBounds(bounds: LatLngBounds): void;
+      }
+
+      class Marker {
+        constructor(options: {
+          position: LatLng;
+          map: Map;
+          title?: string;
+        });
+        setMap(map: Map | null): void;
+      }
+
+      class Polyline {
+        constructor(options: {
+          path: LatLng[];
+          strokeWeight: number;
+          strokeColor: string;
+          strokeOpacity: number;
+          map: Map;
+        });
+        setMap(map: Map | null): void;
+      }
+
+      namespace event {
+        function addListener(
+          target: any,
+          type: string,
+          handler: () => void
+        ): void;
+
+        function removeListener(
+          target: any,
+          type: string,
+          handler: () => void
+        ): void;
+      }
+
+      function load(callback: () => void): void;
     }
   }
-  
-  export {};
+}

--- a/src/shared/model/kakao.maps.d.ts
+++ b/src/shared/model/kakao.maps.d.ts
@@ -21,12 +21,22 @@ declare global {
           }) => {
             setMap: (map: any) => void;
           };
+          Polyline: new (options: {
+            path: any[];
+            strokeWeight: number;
+            strokeColor: string;
+            strokeOpacity: number;
+            map: any;
+          }) => {
+            setMap: (map: any) => void;
+          };
           event: {
             addListener: (target: any, type: string, handler: () => void) => void;
             removeListener: (target: any, type: string, handler: () => void) => void;
           };
         };
       };
+      polylines: any[];
     }
   }
   

--- a/src/shared/model/mocks/mockLocationData.ts
+++ b/src/shared/model/mocks/mockLocationData.ts
@@ -2,28 +2,28 @@ export const mockLocationData = {
     locations: [
       {
         id: "A",
-        name: "서울시청",
-        lat: 37.5665,
-        lng: 126.9780,
+        name: "노원구청",
+        lat: 37.6544,
+        lng: 127.0568,
       },
       {
         id: "B",
-        name: "마포구청",
-        lat: 37.5796,
-        lng: 126.8904,
+        name: "양천구청",
+        lat: 37.5163,
+        lng: 126.8664,
       },
       {
         id: "C",
-        name: "건대입구역",
-        lat: 37.5512,
-        lng: 127.0732,
+        name: "송파구청",
+        lat: 37.5146,
+        lng: 127.1056,
       },
     ],
     midpoint: {
       id: "MID",
       name: "중간 지점",
-      lat: 37.5658,
-      lng: 126.9805,
+      lat: 37.5610,
+      lng: 127.0100, // 중구 근처로 평균값 조정
     },
   };
   

--- a/src/shared/model/mocks/mockLocationData.ts
+++ b/src/shared/model/mocks/mockLocationData.ts
@@ -1,0 +1,29 @@
+export const mockLocationData = {
+    locations: [
+      {
+        id: "A",
+        name: "서울시청",
+        lat: 37.5665,
+        lng: 126.9780,
+      },
+      {
+        id: "B",
+        name: "마포구청",
+        lat: 37.5796,
+        lng: 126.8904,
+      },
+      {
+        id: "C",
+        name: "건대입구역",
+        lat: 37.5512,
+        lng: 127.0732,
+      },
+    ],
+    midpoint: {
+      id: "MID",
+      name: "중간 지점",
+      lat: 37.5658,
+      lng: 126.9805,
+    },
+  };
+  

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2020",
     "useDefineForClassFields": true,

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -24,7 +24,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "types": ["node"]
   },
   "include": ["src"]
 }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -25,7 +25,8 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "types": ["node"]
+    "types": ["node"],
+    "typeRoots": ["./node_modules/@types", "./src/shared/model"]
   },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,5 +3,11 @@
   "references": [
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.node.json" }
-  ]
+  ],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import path from "path";
+import { fileURLToPath } from "url";
+import { dirname, resolve } from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -8,7 +12,7 @@ export default defineConfig({
   base: "/",
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "src"),
+      "@": resolve(__dirname, "src"),
     },
   },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import path from "path";
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: "/",
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
 });


### PR DESCRIPTION
# 🛠 구현 사항

- 카카오 지도 연동
- 카카오 마커 구현
- 처음에 모든 마커가 보이도록 bounds 설정
- polyline으로 중심 좌표연결
- strictmode제거 및 배포환경 라우팅 오류 수정

# ❓ 질문

x

# 📸 화면 캡처
<img width="1102" alt="스크린샷 2025-04-11 오후 2 48 56" src="https://github.com/user-attachments/assets/abadb985-8b67-4a4c-bd90-164e6bfb4435" />


# 💬 리뷰 요구사항

- 마커 및 폴리라인 관련 카카오맵 API 활용 방식을 확인해 주세요.
- 코드 분리 및 컴포넌트 구조에 개선 여지가 있는지도 피드백 주시면 감사하겠습니다.
- 오버레이 마커는 추후 SVG기반 커스텀으로 구현할 것 입니다.